### PR TITLE
Make sure all ticket selections are removed from TS once added.

### DIFF
--- a/scripts/multi_event_registration.js
+++ b/scripts/multi_event_registration.js
@@ -443,6 +443,7 @@ jQuery( document ).ready( function( $ ) {
 				if ( $( this ).find( 'option[value="0"]' ).length > 0 ) {
 					$( this ).val( 0 );
 				}
+				$( this ).prop( 'checked', false );
 			} );
 		},
 


### PR DESCRIPTION
If you set the event to only allow 1 ticket per order the ticket selector uses radio buttons, we need to clear those selections when they have been added to the cart.

This code is from @tn3rb I'm just adding it in.