### PR TITLE
Bug/fix current results ticket count

### DIFF
--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -725,17 +725,16 @@ class EED_Multi_Event_Registration extends EED_Module {
 		$response = array( 'tickets_added' => false );
 		if ( EED_Ticket_Selector::instance()->process_ticket_selections() ) {
 			$EVT_ID = absint( EE_Registry::instance()->REQ->get( 'tkt-slctr-event-id', 0 ) );
-			//$tickets = EE_Registry::instance()->REQ->get( 'tkt-slctr-qty-' . $EVT_ID, array() );
-			$ticket_count = EE_Registry::instance()->CART->all_ticket_quantity_count();
-			//$ticket_count = 0;
-			//// radio buttons send ticket info as a string like: "TKT_ID-QTY"
-			//if ( ! is_array( $tickets ) ) {
-			//	$tickets = explode( '-', $tickets );
-			//	array_shift( $tickets );
-			//}
-			//foreach ( $tickets as $quantity ) {
-			//	$ticket_count += $quantity;
-			//}
+			$tickets = EE_Registry::instance()->REQ->get( 'tkt-slctr-qty-' . $EVT_ID, array() );
+			$ticket_count = 0;
+			// radio buttons send ticket info as a string like: "TKT_ID-QTY"
+			if ( ! is_array( $tickets ) ) {
+				$tickets = explode( '-', $tickets );
+				array_shift( $tickets );
+			}
+			foreach ( $tickets as $quantity ) {
+				$ticket_count += $quantity;
+			}
 			$response = array(
 				'tickets_added' 	=> true,
 				'ticket_count' 		=> $ticket_count,


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Incorrect count of tickets that were just added to the cart. It should show the number of items that were added with the very last addition to the cart. Instead, it shows the total number of items in the cart.
## How has this been tested
Added items to the event cart from a few different events. Also checked reserved counts to make sure those were correctly incremented.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
