### PR TITLE
Add listener to hide cart modal by pressing the Escape key

### DIFF
--- a/scripts/multi_event_registration.js
+++ b/scripts/multi_event_registration.js
@@ -100,6 +100,7 @@ jQuery( document ).ready( function( $ ) {
 			} else {
 				MER.set_listener_for_ticket_selector_submit_btn();
 				MER.set_listener_for_close_modal_btn();
+				MER.set_listener_for_escape_modal();
 			}
 			//alert( 'initialized !' );
 		},
@@ -299,6 +300,25 @@ jQuery( document ).ready( function( $ ) {
 					cart_results_wrapper.eeRemoveOverlay().hide();
 					event.preventDefault();
 					event.stopPropagation();
+				}
+			} );
+		},
+
+
+
+		/**
+		 *  @function set_listener_for_escape_modal
+		 */
+		set_listener_for_escape_modal : function() {
+			$( document ).keyup( function( event ) {
+				if ( event.keyCode == 27 ) {
+					var cart_results_wrapper = $( '#cart-results-modal-wrap-dv' );
+					if ( cart_results_wrapper.length ) {
+						cart_results_wrapper.eeRemoveOverlay().hide();
+						$( '.ticket-selector-submit-ajax' ).focus();
+						event.preventDefault();
+						event.stopPropagation();
+					}
 				}
 			} );
 		},


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Currently you need to click an "x" located in the upper right corner of the cart modal to hide it. This PR adds the possibility of using the escape key.

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Browser based testing, tested with Firefox only.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
