### PR TITLE
Event Cart page: Set top margin only, leave side margins alone

### DIFF
--- a/css/multi_event_registration.css
+++ b/css/multi_event_registration.css
@@ -1,6 +1,6 @@
 /*****   Event Cart   *****/
 
-#event-cart { margin:2em 0 0;}
+#event-cart { margin-top:2em; }
 
 #event-cart-qty-frm .ui-widget-header { padding:0 1em; }
 #event-cart-qty-frm .event-cart-wrap-dv { margin:0!important; }


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
The twentynineteen theme doesn't wrap the content with the container, and I think other themes will follow since that open up some cool things you can do with the new block editor. So we'll need to be careful and avoid setting right & left margins to 0. 
screenshot example:
<img width="1174" alt="screen shot 2018-11-02 at 8 57 30 am" src="https://user-images.githubusercontent.com/891156/47918277-839cb480-de82-11e8-96e2-c887ef009faa.png">


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Tested with the twentynineteen theme current master.
## Checklist

This is only a CSS so most of the checklist does not apply.
* [x] My code is tested.

