### PR TITLE
remove dangling commas in JS that causes syntax erorrs in ie 11

### DIFF
--- a/scripts/multi_event_registration.js
+++ b/scripts/multi_event_registration.js
@@ -146,7 +146,7 @@ jQuery( document ).ready( function( $ ) {
 					}
 					event.preventDefault();
 					event.stopPropagation();
-				},
+				}
 			);
 		},
 
@@ -177,7 +177,7 @@ jQuery( document ).ready( function( $ ) {
 							: '';
 						MER.submit_ajax_request();
 					}
-				},
+				}
 			);
 		},
 
@@ -208,7 +208,7 @@ jQuery( document ).ready( function( $ ) {
 							: '';
 						MER.submit_ajax_request();
 					}
-				},
+				}
 			);
 		},
 
@@ -251,7 +251,7 @@ jQuery( document ).ready( function( $ ) {
 					}
 					event.preventDefault();
 					event.stopPropagation();
-				},
+				}
 			);
 		},
 
@@ -271,7 +271,7 @@ jQuery( document ).ready( function( $ ) {
 					}
 					event.preventDefault();
 					event.stopPropagation();
-				},
+				}
 			);
 		},
 
@@ -599,7 +599,7 @@ jQuery( document ).ready( function( $ ) {
 			} else if ( MER.ticket_selector_iframe ) {
 				MER.show_event_cart_ajax_msg( 'success',
 					eei18n.iframe_tickets_added,
-					6000,
+					6000
 				);
 			}
 


### PR DESCRIPTION



<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
There were javascript syntax errors using Internet Explorer 11. Eg on https://www.brickchurchschool.org/events/emily-brown/. Here is a vidoe of me attempting to register on the site: https://drive.google.com/file/d/1G1aYrmNooyaiI80Bll1Y2V92gjfUaNb2/view (playing Daft Punk in the background).

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
* [x] Activate MER on a site and visit it using Internet Explorer 11 and try to add an event to the cart (you may need to deactivate invisible recaptcha)
* [ ] Try again using a Triassic period-or-later browser. It should still work fine.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
