### PR TITLE
Add filter hook to toggle display of line items, add to html, fixes #17

### DIFF
--- a/EE_Event_Cart_Line_Item_Display_Strategy.php
+++ b/EE_Event_Cart_Line_Item_Display_Strategy.php
@@ -71,9 +71,15 @@ class EE_Event_Cart_Line_Item_Display_Strategy implements EEI_Line_Item_Display 
 				} else {
 					$html .= $this->_item_row( $line_item, $options );
 				}
-				// got any kids?
-				foreach( $line_item->children() as $child_line_item ) {
-					$this->display_line_item( $child_line_item, $options );
+				if (apply_filters(
+                    'FHEE__EE_Event_Cart_Line_Item_Display_Strategy__display_line_item__display_sub_line_items',
+                    false
+                )
+                ) {
+					// got any kids?
+					foreach( $line_item->children() as $child_line_item ) {
+						$html .= $this->display_line_item( $child_line_item, $options );
+					}
 				}
 				break;
 


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See issue #17, this is a work in progress because how the sub line items are displayed needs some tweaking.
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Add this code to a functions file to display sub line items:
`add_filter('FHEE__EE_Event_Cart_Line_Item_Display_Strategy__display_line_item__display_sub_line_items', '__return_true');
`

Then try a variety of events that have tickets with: taxes, percent surcharges, percent discounts, fixed-rate surcharges & discounts, all with a variety of quantities of tickets from events.


## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
