### PR TITLE
Don't show the description of the event in the minicart widget (list template)

### DIFF
--- a/EE_Mini_Cart_List_Line_Item_Display_Strategy.php
+++ b/EE_Mini_Cart_List_Line_Item_Display_Strategy.php
@@ -270,7 +270,7 @@ class EE_Mini_Cart_List_Line_Item_Display_Strategy implements EEI_Line_Item_Disp
 			return '';
 		}
 		// total td
-		$content = EEH_HTML::strong( $line_item->desc() . ' ' . $text );
+		$content = EEH_HTML::strong( $line_item->name() . ' ' . $text );
 		// total td
 		$content .= ' ' . EEH_HTML::strong( $line_item->total_no_code() );
 		return EEH_HTML::li( $content, '', 'event-cart-total-list total-list', 'text-align:right; width:100%;' );

--- a/EE_Mini_Cart_List_Line_Item_Display_Strategy.php
+++ b/EE_Mini_Cart_List_Line_Item_Display_Strategy.php
@@ -269,8 +269,11 @@ class EE_Mini_Cart_List_Line_Item_Display_Strategy implements EEI_Line_Item_Disp
 		if ( $tax_total && $this->_tax_count < 2 ) {
 			return '';
 		}
+		if ( $line_item->OBJ_type() === 'Event' ) {
+			return '';
+		}
 		// total td
-		$content = EEH_HTML::strong( $line_item->name() . ' ' . $text );
+		$content = EEH_HTML::strong( $text );
 		// total td
 		$content .= ' ' . EEH_HTML::strong( $line_item->total_no_code() );
 		return EEH_HTML::li( $content, '', 'event-cart-total-list total-list', 'text-align:right; width:100%;' );

--- a/css/multi_event_registration.css
+++ b/css/multi_event_registration.css
@@ -157,6 +157,14 @@
     text-align: right;
 }
 
+.event-cart-total-list {
+    margin: 1em 0 0;
+}
+
+.event-cart-total-list ~ .event-cart-total-list {
+    margin: 0;
+}
+
 /* Media Query for screens smaller then 768px (iPad portrait)
 ---------------------------------------------------------------------------------------------------- */
 


### PR DESCRIPTION
A support token happened because they saw unparsed shortcode content (from the event's description) in the minicart widget. https://eventespresso.com/topic/continuing-issue-with-errant-programming-code-appearing-in-event-cart/#post-297863

![Screen Shot 2019-08-16 at 8 06 50 PM](https://user-images.githubusercontent.com/891156/63204060-1e592f00-c062-11e9-86a2-314c18d531c5.png)


I tracked this down to the mini cart list line item display strategy and it appears to be a simple fix where the subtotal could use the line item name instead.

![Screen Shot 2019-08-16 at 8 05 43 PM](https://user-images.githubusercontent.com/891156/63204064-23b67980-c062-11e9-96e0-7591e12779a5.png)


To test this, activate the mini cart event widget (select the list option). You'll need two events, each needs an event description (with more than a few words in the event description to test the full effect). Add tickets to both events, **do not input anything into the ticket description field**. 

Then add tickets from both events to the cart. This branch will make the subtotal line show the event's name, not the event's description.

## Checklist
* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
