### PR TITLE
Fix return to cart button if it's an ajax request Fixes #11

### DIFF
--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -230,6 +230,11 @@ class EED_Multi_Event_Registration extends EED_Module {
 			array( 'EED_Multi_Event_Registration', 'display_availability_error' ),
 			10, 1
 		);
+		add_filter(
+			'FHEE__EE_SPCO_Reg_Step__reg_step_submit_button__sbmt_btn_html',
+			array(  'EED_Multi_Event_Registration', 'return_to_event_cart_button' ),
+			10, 2
+		);
 		// update cart in session
 		add_action( 'shutdown', array( 'EED_Multi_Event_Registration', 'save_cart' ), 10 );
 	}


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
See #11 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

Activate MER with this branch checked out, 
add some registrations to your cart, 
proceed through until you get to the payment options, 
verify the 'Return to cart' button is shown

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
* [x] My code accounts for when the site is in Maintenance Mode (MM2 especially disallows usage of models)
