### PR TITLE
Filter localized vars and set disable_submit to true.

### DIFF
--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -156,6 +156,11 @@ class EED_Multi_Event_Registration extends EED_Module {
 			array( 'EED_Multi_Event_Registration', 'toggle_registration_status_if_no_monies_owing' ),
 			10, 2
 		);
+		// setup reCaptcha
+		add_filter( 'FHEE__EventEspresso_caffeinated_modules_recaptcha_invisible_InvisibleRecaptcha__getLocalizedVars__localized_vars',
+			array( 'EED_Multi_Event_Registration', 'setInvisiblerecaptchaLocalizedVars' ),
+			10, 1
+		);
 		// display errors
 		add_action( 'wp_footer', array( 'EED_Multi_Event_Registration', 'cart_results_modal_div' ), 1 );
 		// update cart in session
@@ -2211,6 +2216,20 @@ class EED_Multi_Event_Registration extends EED_Module {
 		}
 	}
 
+
+	/**
+	 * setInvisiblerecaptchaLocalizedVars
+	 * This filters \EventEspresso\caffeinated\modules\recaptcha_invisible\InvisibleRecaptcha::getLocalizedVars() 
+	 * to set disable_submit to true.
+	 *
+	 * @access public
+	 * @param array $localizedVars
+	 * @return array
+	 */
+	public static function setInvisiblerecaptchaLocalizedVars($localizedVars) {
+		$localizedVars['disable_submit'] = true;
+		return $localizedVars;
+	}
 
 
 }

--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -2222,11 +2222,10 @@ class EED_Multi_Event_Registration extends EED_Module {
 	 * This filters \EventEspresso\caffeinated\modules\recaptcha_invisible\InvisibleRecaptcha::getLocalizedVars() 
 	 * to set disable_submit to true.
 	 *
-	 * @access public
 	 * @param array $localizedVars
 	 * @return array
 	 */
-	public static function setInvisiblerecaptchaLocalizedVars($localizedVars) {
+	public static function setInvisiblerecaptchaLocalizedVars(array $localizedVars) {
 		$localizedVars['disable_submit'] = true;
 		return $localizedVars;
 	}


### PR DESCRIPTION
See #19 

## Problem this Pull Request solves
Filters `\EventEspresso\caffeinated\modules\recaptcha_invisible\InvisibleRecaptcha::getLocalizedVars()` to set disable_submit from within MER.

## How has this been tested
Use this branch and confirm that the ticket selector and registration form both work as expected with Invisible reCaptcha setup

To set reCaptcha up go to Event Espresso -> Registration Form ->Reg form settings.

You'll need keys and make sure you set it to use Invisible reCaptcha.

(Note that you'll need to test this whilst logged out of the site/private window to confirm it works)

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
