### PR TITLE
Prevent SPCO assets loading on the cart view.

### DIFF
--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -916,6 +916,9 @@ class EED_Multi_Event_Registration extends EED_Module {
 		$grand_total = EE_Registry::instance()->CART->get_grand_total();
 		$grand_total->recalculate_total_including_taxes();
 
+		//Set the SPCO_active filter to false as this is view is technically not SPCO.
+		add_filter('EED_Single_Page_Checkout__SPCO_active', '__return_false', 20);
+
 		// autoload Line_Item_Display classes
 		$template_args[ 'event_cart_heading' ] = apply_filters(
 			'FHEE__EED_Multi_Event_Registration__view_event_cart__event_cart_heading',

--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -916,7 +916,7 @@ class EED_Multi_Event_Registration extends EED_Module {
 		$grand_total = EE_Registry::instance()->CART->get_grand_total();
 		$grand_total->recalculate_total_including_taxes();
 
-		//Set the SPCO_active filter to false to pevent assests that rely on single_page_checkout from loading.
+		// Set the SPCO_active filter to false to pevent assests that rely on single_page_checkout from loading.
 		add_filter('EED_Single_Page_Checkout__SPCO_active', '__return_false', 20);
 
 		// autoload Line_Item_Display classes

--- a/EED_Multi_Event_Registration.module.php
+++ b/EED_Multi_Event_Registration.module.php
@@ -916,7 +916,7 @@ class EED_Multi_Event_Registration extends EED_Module {
 		$grand_total = EE_Registry::instance()->CART->get_grand_total();
 		$grand_total->recalculate_total_including_taxes();
 
-		//Set the SPCO_active filter to false as this is view is technically not SPCO.
+		//Set the SPCO_active filter to false to pevent assests that rely on single_page_checkout from loading.
 		add_filter('EED_Single_Page_Checkout__SPCO_active', '__return_false', 20);
 
 		// autoload Line_Item_Display classes


### PR DESCRIPTION
See here: https://eventespresso.com/topic/single-page-checkout-missing/

Assets with a dependency on single_page_checkout are still loading when we view MER's event cart as its kinda SPCO but not :)

This change just filters `EED_Single_Page_Checkout__SPCO_active` and sets it to false when we load the cart.

## Problem this Pull Request solves
Add [query monitor](https://en-gb.wordpress.org/plugins/query-monitor/) to a site and view the event cart.

You'll see a notice about missing dependencies for the `add_new_state.js` file from core and if you have promotions active you'll also see the same for `promotions.js`.

Switch to this branch of MER and refresh or repeat the test, now you'll see no notice of missing dependencies. The 2 .js files mentioned above shouldn't even load on that page.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
